### PR TITLE
HB-11110: change the pipelines portal urls

### DIFF
--- a/vars/buildCommerceCloud.groovy
+++ b/vars/buildCommerceCloud.groovy
@@ -3,7 +3,7 @@ def call(branch, buildName) {
     //deploy tag 
     script{
         withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'commerceCloudCredentials', usernameVariable: 'subscriptionId', passwordVariable: 'token']]) {
-            build = sh (script: "curl --location --request POST 'https://portalrotapi.hana.ondemand.com/v2/subscriptions/${subscriptionId}/builds' --header 'Content-Type: application/json' --header 'Authorization: Bearer ${token}' --header 'Content-Type: text/plain' --data-raw '{\"branch\": \"${branch}\",\"name\": \"${buildName}\"}'",returnStdout:true)
+            build = sh (script: "curl --location --request POST 'https://portalapi.commerce.ondemand.com/v2/subscriptions/${subscriptionId}/builds' --header 'Content-Type: application/json' --header 'Authorization: Bearer ${token}' --header 'Content-Type: text/plain' --data-raw '{\"branch\": \"${branch}\",\"name\": \"${buildName}\"}'",returnStdout:true)
             echo "$build"
             build_result = readJSON text: "$build"
             code_number = build_result["code"]

--- a/vars/buildCommerceCloudCheck.groovy
+++ b/vars/buildCommerceCloudCheck.groovy
@@ -2,7 +2,7 @@ def call(codeNumber) {
     script {
         while (true) {
           withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'commerceCloudCredentials', usernameVariable: 'subscriptionId', passwordVariable: 'token']]) {
-              result = sh (script: "curl --location --request GET 'https://portalrotapi.hana.ondemand.com/v2/subscriptions/${subscriptionId}/builds/$codeNumber' --header 'Authorization: Bearer ${token}'",returnStdout:true)
+              result = sh (script: "curl --location --request GET 'https://portalapi.commerce.ondemand.com/v2/subscriptions/${subscriptionId}/builds/$codeNumber' --header 'Authorization: Bearer ${token}'",returnStdout:true)
           }
           echo "$result"
           statusResult = readJSON text: "$result"

--- a/vars/commerceCloudDeploy.groovy
+++ b/vars/commerceCloudDeploy.groovy
@@ -3,7 +3,7 @@ def call(buildName, dbUpdateMode, environmentId, strategy) {
     //deploy tag 
     script{
         withCredentials([[$class: 'UsernamePasswordMultiBinding', credentialsId: 'commerceCloudCredentials', usernameVariable: 'subscriptionId', passwordVariable: 'token']]) {
-            deploy = sh (script: "curl --location --request POST 'https://portalrotapi.hana.ondemand.com/v2/subscriptions/${subscriptionId}/deployments' --header 'Content-Type: application/json' --header 'Authorization: Bearer ${token}' --header 'Content-Type: text/plain' --data-raw '{\"buildCode\": \"${buildName}\",\"databaseUpdateMode\": \"${dbUpdateMode}\",\"environmentCode\": \"${environmentId}\",\"strategy\": \"${strategy}\"}'",returnStdout:true)
+            deploy = sh (script: "curl --location --request POST 'https://portalapi.commerce.ondemand.com/v2/subscriptions/${subscriptionId}/deployments' --header 'Content-Type: application/json' --header 'Authorization: Bearer ${token}' --header 'Content-Type: text/plain' --data-raw '{\"buildCode\": \"${buildName}\",\"databaseUpdateMode\": \"${dbUpdateMode}\",\"environmentCode\": \"${environmentId}\",\"strategy\": \"${strategy}\"}'",returnStdout:true)
             echo "$deploy"
             deploy_result = readJSON text: "$deploy"
             deploy_code = deploy_result["code"]

--- a/vars/commerceCloudDeployCheck.groovy
+++ b/vars/commerceCloudDeployCheck.groovy
@@ -2,7 +2,7 @@ def call(deployCode) {
     script {
         while (true) {
           wrap([$class: 'MaskPasswordsBuildWrapper', varPasswordPairs: [[password: "${token}", var: 'PASSWD']]]) {
-              result = sh (script: "curl --location --request GET 'https://portalrotapi.hana.ondemand.com/v2/subscriptions/${subscriptionId}/deployments/$deployCode' --header 'Authorization: Bearer ${token}'",returnStdout:true)
+              result = sh (script: "curl --location --request GET 'https://portalapi.commerce.ondemand.com/v2/subscriptions/${subscriptionId}/deployments/$deployCode' --header 'Authorization: Bearer ${token}'",returnStdout:true)
           }
           echo "$result"
           statusResult = readJSON text: "$result"


### PR DESCRIPTION
Hi Abhishek,

I doubld cofirmed with our CSO team.

The url https://portalrotapi.hana.ondemand.com/ behinds CDN and should not be exposed to the customer

Also our CSO team did portal migration during weekend, so please use the correct api url https://portalapi.commerce.ondemand.com/v2/subscriptions/5416ea93eb324720a548e0690064c59c/builds

Please feel free to let us know if you have any further query.

Best Regards,
Dale
SAP Support